### PR TITLE
Add proxy request headers

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,10 @@
 server {
     listen       80;
     server_name  localhost;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $server_name;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     location / {
         proxy_pass http://app:8000;


### PR DESCRIPTION
## Context

My reverse proxy should be add the following info as part of the request headers:

'X-Real-IP' - the clients IP addr that the request originates from.
'X-Forwarded-For' - A list of host IP addresses that the request went through.
'X-forwarded-host' - Host name that the request went through before getting to the backend server