### PR TITLE
Run nginx containers as non root

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,3 +1,6 @@
 FROM nginx:latest
 
 RUN useradd -U app_user
+
+RUN install -d -m 0755 -o app_user -g app_user /usr/share/nginx/staticfiles \
+    && install -m 0644 -o app_user -g app_user /dev/null /var/run/nginx.pid

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -4,3 +4,6 @@ RUN useradd -U app_user
 
 RUN install -d -m 0755 -o app_user -g app_user /usr/share/nginx/staticfiles \
     && install -m 0644 -o app_user -g app_user /dev/null /var/run/nginx.pid
+
+COPY --chown=app_user:app_user ./nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --chown=app_user:app_user ./nginx/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,3 +1,3 @@
 FROM nginx:latest
 
-RUN mkdir -p /home/app/staticfiles
+RUN useradd -U app_user

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -12,3 +12,7 @@ RUN chown -R app_user:app_user \
     /var/cache/nginx \
     /var/log/nginx \
     /etc/nginx/conf.d
+
+USER app_user:app_user
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -7,3 +7,8 @@ RUN install -d -m 0755 -o app_user -g app_user /usr/share/nginx/staticfiles \
 
 COPY --chown=app_user:app_user ./nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --chown=app_user:app_user ./nginx/nginx.conf /etc/nginx/nginx.conf
+
+RUN chown -R app_user:app_user \
+    /var/cache/nginx \
+    /var/log/nginx \
+    /etc/nginx/conf.d

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,5 @@
 FROM nginx:latest
+LABEL contributor="Owen O. Phakade <olwethuphakade89@gmail.com>"
 
 RUN useradd -U app_user
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ services:
     depends_on:
       - app
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
-      - django_static_volume:/home/app/staticfiles
+      - django_static_volume:/usr/share/nginx/staticfiles
 
 volumes:
   django_static_volume:


### PR DESCRIPTION
## Context

For security purposes, It's always advised to run containers as a non root user. This PR sets permission and ownership for a container using a Dockerfile. 