### PR TITLE
Create container resource limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,17 +10,21 @@ services:
       - ./.env/django.env
     volumes:
       - django_static_volume:/app/staticfiles
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
   web:
     container_name: nginx_container
     image: django_web:latest
     ports:
-      - 80:80
+      - 8080:80
     depends_on:
       - app
     env_file:
       - ./.env/nginx.env
     volumes:
       - django_static_volume:/usr/share/nginx/staticfiles
-      
 volumes:
   django_static_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,10 @@ services:
       - ./.env/nginx.env
     volumes:
       - django_static_volume:/usr/share/nginx/staticfiles
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128M
 volumes:
   django_static_volume:


### PR DESCRIPTION
## Context

I need to add container resource limits that'll emulate limits defined in my production task definition config because containers will be deployed to t2.micro instances. Max allocated resources for per instance in free tier are: 1vCPU and 1GiB Mem. 